### PR TITLE
Enabled the export 'callback'

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = function(){
   res.getOrganizationInfo = xeroClient.getOrganizationInfo;
   res.syncStatus = xeroClient.syncStatus;
   res.authenticate = xeroClient.requestXeroRequestToken;
+  res.callback = xeroClient.requestXeroAccessToken;
   res._getRequest = xeroClient._getRequest;
   res._postRequest = xeroClient._postRequest;
   res._putRequest = xeroClient._putRequest;


### PR DESCRIPTION
As per the description in the readme, xeroClient.callback should be an
export available to use. I figured it should be attached to
requestXeroAccessToken from the comments, and as such made this change.
